### PR TITLE
fix: Safari redirect problem

### DIFF
--- a/src/tui/caddy_config.go
+++ b/src/tui/caddy_config.go
@@ -45,7 +45,7 @@ func (ui *UI) getLocalDomain() (*url.URL, bool) {
 }
 
 func (ui *UI) getMainCaddyFile() string {
-	return "{\n" +
+	return "{\n" + "auto_https disable_redirects\n" +
 		fmt.Sprintf(
 			"        servers :%v {\n", ui.caddyProxyProtocolPort) +
 		"                listener_wrappers {\n" +


### PR DESCRIPTION
如果Caddyfile中不配置auto_https disable_redirects的话，Safari在访问搭建所用域名的时候，会redir至8443端口，域名后面会带端口号，比较难看。
Chrome和Firefox则没有这个问题。
需要建站的话，还是redir至443会好一些。
配置auto_https disable_redirects后，Safari才会根据如下配置redir至xray所监听的443端口：
:80 {
  redir https://{host}{url}
}

关于auto_https的Caddy文档：https://caddyserver.com/docs/caddyfile/options#auto-https